### PR TITLE
Require coverage metadata in PHPUnit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
 	stopOnSkipped="false"
 	cacheDirectory=".phpunit.cache"
 	backupStaticProperties="false"
+	requireCoverageMetadata="true"
 >
   <coverage includeUncoveredFiles="true"/>
   <testsuites>


### PR DESCRIPTION
PHPUnit should check for `@covers` annotations and/or `#CoversClass` PHP
attributes. This change will allow us to disable the check in our coding
style, which only supports annotations. The coding style rule would
block us from using attributes and PHPUnit 11 in the future.

Ticket: https://phabricator.wikimedia.org/T359971
